### PR TITLE
Update for newer Rust versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Jihyeok Seo <limeburst@ridi.com>", "Philippe Solodov <solop1906@gmai
 description = "A library for handling ISBNs."
 license = "MIT"
 repository = "https://github.com/philippeitis/isbn-rs"
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
-codegen = "0.1"
-roxmltree = "0.14.1"
+codegen = "0.2"
+roxmltree = "0.20"
 
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
-quick-xml = { version = "0.22.0", optional = true }
-indexmap = { version = "1.7.0", default-features = false, optional = true }
+quick-xml = { version = "0.34", optional = true }
+indexmap = { version = "2.2", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A library for handling ISBNs."
 license = "MIT"
 repository = "https://github.com/philippeitis/isbn-rs"
 edition = "2021"
+rust-version = "1.60.0"
 
 [build-dependencies]
 codegen = "0.2"


### PR DESCRIPTION
Updated this to an MSRV of `1.60` with Rust edition `2021` in order to push some dependencies to more recent versions.